### PR TITLE
Tell cp to follow symbolic links

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -90,14 +90,14 @@ if [ "$deploy_boot" == "y" ]; then
     fi
 
     if [ "$PLATFORM" == "rpi4" ]; then
-        sudo cp -r ../bsp/rpi4/* fs/
+        sudo cp -rL ../bsp/rpi4/* fs/
         sudo cp ../u-boot/u-boot.bin fs/kernel7.img
         ./umount.sh
         cd ..
     fi
     
     if [ "$PLATFORM" == "rpi4_64" -o "$PLATFORM" == "cm4_64" ]; then
-        sudo cp -r ../bsp/rpi4/* fs/
+        sudo cp -rL ../bsp/rpi4/* fs/
         sudo cp ../u-boot/u-boot.bin fs/kernel8.img
         ./umount.sh
         cd ..


### PR DESCRIPTION
The option "-L" tells the "cp" utility to follow symbolic links instead of copying them. It was added to the build.sh file so that the files are copied instead of the symlinks as symlinks aren't supported on the target filesystem (and even if they were, we do want to copy the file not the symlink)